### PR TITLE
Additional configs and spawn chance fix

### DIFF
--- a/AntiStrangulation/Config.cs
+++ b/AntiStrangulation/Config.cs
@@ -1,9 +1,17 @@
-﻿namespace AntiStrangulation
+﻿using System.ComponentModel;
+
+namespace AntiStrangulation
 {
     public class Config
     {
         public bool Debug { get; set; } = false;
         public bool DisableStrangulation { get; set; } = true;
         public bool DisableAutoSpawn { get; set; } = false;
+        
+        [Description("The minimum amount of players that need to be in a server in order for SCP-3114 to spawn")]
+        public int MinimumPlayers { get; set; } = 5;
+
+        [Description("The chance SCP-3114 can spawn (given there are enough players)")]
+        public int SpawnChance { get; set; } = 20;
     }
 }


### PR DESCRIPTION
Heyy, really nice plugin. I made some changes that we wanted to have on our own server and decided to share them. The changes are listed below.

 - Fixed the way spawn chances work, instead of attempting a chance for every spawned SCP, it does it once per round.
 - Spawn chance is now configurable in the plugin config (0%-100%) with a default value of 20%.
 - Added the option to require a minimum amount of players to be on the server for 3114 to spawn. If there are less players, 3114 can no longer spawn (default is 5).